### PR TITLE
feat: add duplicate grade validation

### DIFF
--- a/app/Http/Requests/GradeRequest.php
+++ b/app/Http/Requests/GradeRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Models\Grade;
 use Illuminate\Foundation\Http\FormRequest;
 
 class GradeRequest extends FormRequest
@@ -25,10 +26,21 @@ class GradeRequest extends FormRequest
             'student_id' => 'required|exists:students,id',
             'subject_id' => 'required|exists:subjects,id',
             'grade' => ['required', 'string', function ($attribute, $value, $validator) {
+                $studentId = $this->input('student_id');
+                $subjectId = $this->input('subject_id');
+
+                $existingGrade = Grade::where('student_id', $studentId)
+                    ->where('subject_id', $subjectId)
+                    ->exists();
+                if($existingGrade) {
+                    $validator($attribute, 'Student already has a grade for this subject.');
+                }
+
                 $valid_grades = ["1.00", "1.25", "1.50", "1.75", "2.00", "2.25", "2.50", "2.75", "3.00", "5.00","INC","DRP"];
                 if(!in_array($value, $valid_grades)) {
                     $validator($attribute, 'Invalid grade.');
                 }
+
             }]
         ];
     }


### PR DESCRIPTION
This prevents the user from making duplicate grade record. A duplicate is where the grade to a certain subject is given twice to the same student.
closes #13